### PR TITLE
Add template for embedding Observable d3 viz

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,21 @@ Config.yaml lists the groups of topics (collections) that will be enumerated on 
 If you opt to use the topic grouping folder structure, you'll need to update the grid-topic-cards.html file with the correct group names and the correct folder names.
 
 Individual topic pages have a 'data' attribute. This is used to select the appropriate file name from the image folder for the card display. Ensure you have a matching .jpg file in the image list folder to match the data attribute for every topic. These are case sensitive.
+
+
+## Viz
+
+There is a page template for data visualistions embedded using the JavaScript module from Observable, viz.html. To use this template:
+1. Create a file in the includes folder with the name of your viz, e.g. test-viz.html. Past the embed code from observable in here.
+2. Create a .md file in the root folder. Add the front matter as follows. The 'data' attribute selects a header pic. The viz attribute links to the name of the viz in includes folder, i.e. 'test-viz'.
+
+```---
+layout: viz
+data: about
+viz: test-viz
+title:  Test Viz
+subtitle: test
+isHome: false
+---```
+
+3. In the .md file, add the viz using {% include {{page.viz}}.html %}. Add any other content like headings and metadata around it.

--- a/_includes/test-viz.html
+++ b/_includes/test-viz.html
@@ -1,0 +1,16 @@
+<div id="observablehq-viewof-locType-93c5c087"></div>
+<div id="observablehq-viewof-location-93c5c087"></div>
+<div id="observablehq-chart-93c5c087"></div>
+<!-- <p>Credit: <a href="https://observablehq.com/d/0d0bffba30004e4a">Types of jobs worked by Pacific People in NZ by Nat Dudley</a></p> -->
+
+
+<script type="module">
+  import {Runtime, Inspector} from "https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js";
+  import define from "https://api.observablehq.com/d/0d0bffba30004e4a.js?v=3";
+  new Runtime().module(define, name => {
+    if (name === "viewof locType") return new Inspector(document.querySelector("#observablehq-viewof-locType-93c5c087"));
+    if (name === "viewof location") return new Inspector(document.querySelector("#observablehq-viewof-location-93c5c087"));
+    if (name === "chart") return new Inspector(document.querySelector("#observablehq-chart-93c5c087"));
+    return ["data","color"].includes(name);
+  });
+  </script>

--- a/_layouts/viz.html
+++ b/_layouts/viz.html
@@ -1,0 +1,51 @@
+---
+layout: homepage
+---
+<style>
+  .cover-image {
+      background: url('{{site.baseurl}}/assets/img/extra-wide/{{ page.data }}.png') center no-repeat; 
+      background-size: cover;
+  }
+  @media only screen and (max-width: 650px) {
+      .cover-image {
+          background-image: url('{{site.baseurl}}/assets/img/tile/{{ page.data }}.png');
+      }
+  }
+  @media only screen and (max-width: 650px) and (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) { 
+  .cover-image {
+      background-image: url('{{site.baseurl}}/assets/img/banner/{{ page.data }}.png');
+      }
+  }
+  @media only screen and (max-width: 1300px) {
+      .cover-image {
+          background-image: url('{{site.baseurl}}/assets/img/banner/{{ page.data }}.png');
+      }
+  }
+  @media only screen and (max-width: 1300px) and (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) { 
+  .cover-image {
+      background-image: url('{{site.baseurl}}/assets/img/wide/{{ page.data }}.png');
+      }
+  }
+  @media only screen and (max-width: 2600px) {
+      .cover-image {
+          background-image: url('{{site.baseurl}}/assets/img/wide/{{ page.data }}.png');
+      }
+  }
+  @media only screen and (max-width: 2600px) and (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) { 
+  .cover-image {
+      background-image: url('{{site.baseurl}}/assets/img/extra-wide/{{ page.data }}.png');
+      }
+  }
+</style>
+
+<article class="article-page">
+  <div class="page-image">
+      <div class="cover-image"></div>
+  </div>
+  <div class="wrapper viz text">
+      <div class="page-content">
+          {{content}}
+      </div> 
+  </div>        
+</article>
+

--- a/_sass/_find-your-place.scss
+++ b/_sass/_find-your-place.scss
@@ -146,6 +146,16 @@ pre {
   position: relative;
 }
 
+.wrapper.viz {
+  width: 95vw;
+  max-width: 95%;
+  margin: 0 auto;
+  position: relative;
+  p {
+    margin-left: 0;
+  }
+}
+
 ::-moz-selection {
   background: $dark-slate;
   color: $white;

--- a/_sass/_fypmedia.scss
+++ b/_sass/_fypmedia.scss
@@ -148,6 +148,12 @@
   .wrapper.text {
     width: 960px;
   }
+  .wrapper.viz.text {
+    width: 80vw;
+    max-width: 80%;
+    margin: 0 auto;
+    position: relative;
+  }
   .two-col-container {
     .two-col-card.text {
       h1 {

--- a/viz.md
+++ b/viz.md
@@ -1,0 +1,38 @@
+---
+layout: viz
+data: about
+viz: test-viz
+title:  Test Viz
+subtitle: test
+isHome: false
+---
+
+# {{ page.title }}
+
+Use this visualisation to explore the types of jobs worked by Pacific people in Aotearoa. You can explore different parts of the country, and look at the number of people who work in each type of job.
+
+The categories in the centre are more general groups like labourers, managers, and professionals. These are called "Major Groups". Around the outer ring, you'll see "Minor Groups". These are more detailed groups of jobs. For example "Labourers" is a major group, which includes the minor group "Construction and Mining Labourers".
+
+Clicking on one of these will zoom in, enabling you to see a breakdown of that group. When you're looking at the most detailed level, individual jobs, you'll be able to see the number of people who work in that job, and the median and mean total personal annual income for people who work that job in the geographic area you've chosen. Hover over any segment to see the numbers, or click on a detailed segment and the numbers will appear in the centre.
+
+Click the center to zoom back out.
+
+{% include {{page.viz}}.html %}
+
+## About this data
+
+This data comes from Stats NZ and the 2018 census.
+
+Occupation data is classified using the ANZSCO classification. Where it appears, "nec" means "not elsewhere classified," a summary category that collects everyone in an occupational group that does not have a more specific description.
+
+As census data, the income data shown is the total income from all sources, not just the income from the occupation listed. This is called 'Total personal income received'. Total personal income received is the total before-tax income of a person in the 12 months ended 31 March 2018. When you're looking at this data and the income for people working each job, be aware the total personal income received measure includes when a person works multiple jobs, has income from government benefits, or has income from other sources such as rental properties, stocks, or investments. On the whole, we think this is still a useful measure as it helps us understand the overall financial position for income for people working in each job type.
+
+Data at some levels is suppressed for confidentiality reasons. Where the number of people working in a job is suppressed, this data does not appear in the visualisation. Where the median or mean income is suppressed, the data shows the total number of people, but not the income figures.
+
+The Census uses random rounding to base 3. This means figures are randomly rounded up or down to the closest multiple of 3. Sometimes, this means that breakdowns may not add up to the total. You should especially pay attention to this when looking at figures with small numbers, such as as local board area level.
+
+The 2018 Census had lower-than-expected response rates, especially in some parts of New Zealand and with Pacific peoples. This means Census data was combined with other government data (administrative data) using a process called imputation to fill the gaps. Some areas had a particularly low response rate, and you should be extra careful when interpreting that data. 
+
+For occupation, the response rate from 2018 Census forms was 79.7%. The remaining 20.3% of responses were imputed. The significant use of imputation may have inflated the total number of respondents in all categories.
+
+For personal income, the response rate from 2018 Census forms was 81.2%. 16.5% were sourced from administrative data supplied by Inland Revenue. 2.3% of responses were imputed.


### PR DESCRIPTION
this branch adds a template and directions for embedding a visualisation made on observable using d3.

it's a first attempt at how we might do this. It:

- adds a new layout which is wider than usual article page
- adds an example .md file in root folder which would generate vis page
- adds a new _include layout that has an example of the JS necessary for each vis
- adds minor CSS changes to support wider page layout.
- updates readme to explain how this works.

It does not, as yet, add to menu structure as this needs to be configured in config.yaml

Nor does it add it to the homepage.